### PR TITLE
chore: add cat and fap-pci repos

### DIFF
--- a/otterdog/eclipse-xfsc.jsonnet
+++ b/otterdog/eclipse-xfsc.jsonnet
@@ -1261,5 +1261,34 @@ orgs.newOrg('technology.xfsc', 'eclipse-xfsc') {
         'aviation'
       ],
     },
+
+  newXFSCRepo('cat-enhnacements') {
+      description: 'The Federated Catalogue under XFSC has been enhanced to align with FACIS requirements, improving the way metadata objects are managed and verified.',
+      topics: [
+        'facis',
+        'catalogue',
+        'enhancements'
+      ],
+    },
+ 
+  newXFSCRepo('cat-integration-tests') {
+      description: 'BDD test suite for catalogue enhancements.',
+      topics: [
+        'facis',
+        'catalogue',
+        'enhancements',
+        'bdd'
+      ],
+    },
+
+  newXFSCRepo('facis-fap-principal-credential-issuance') {
+      description: 'The FAP on Principal credential issuance (PCI) help organizations create and give out digital credentials to their employees in a safe and simple way. ',
+      topics: [
+        'facis',
+        'fap',
+        'pci',
+        'credential'
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Three new repos has been added at eclipse-xfsc

1. cat-enhancements -> A repo for federated catalogue enhancements which aligns with FACIS requirements.
2. cat-integration-tests -> A Bdd test repo for federated catalogue enhancements.
3. facis-fap-principal-credential-issuance -> A new FAP repo for issuing credentials within the verified employees.